### PR TITLE
Bump core version in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     at_home_in_vitro_test_kit (0.9.0)
-      inferno_core (~> 0.4.4)
+      inferno_core (~> 0.4.37)
 
 GEM
   remote: https://rubygems.org/

--- a/at_home_in_vitro_test_kit.gemspec
+++ b/at_home_in_vitro_test_kit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description       = 'Inferno tests for the At Home In Vitro IG'
   spec.homepage      = 'https://github.com/inferno-framework/inferno-template'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '~> 0.4.4'
+  spec.add_runtime_dependency 'inferno_core', '~> 0.4.37'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'


### PR DESCRIPTION
# Summary
Just bumps the core dependency in the gemspec to a version that supports the HL7 wrapper (specifically, 0.4.37, the latest version as of today)