### PR TITLE
version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    at_home_in_vitro_test_kit (0.9.0)
+    at_home_in_vitro_test_kit (0.10.0)
       inferno_core (~> 0.4.37)
 
 GEM
@@ -170,7 +170,7 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0507)
+    mime-types-data (3.2024.0604)
     mini_portile2 (2.8.7)
     minitest (5.23.1)
     multi_json (1.15.0)

--- a/lib/at_home_in_vitro_test_kit/version.rb
+++ b/lib/at_home_in_vitro_test_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtHomeInVitroTestKit
-    VERSION = '0.9.0'
+    VERSION = '0.10.0'
 end


### PR DESCRIPTION
# Summary
* FI-2395: Data rights legend by @bmath10 in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/3
* Dependency Updates 2024-03-19 by @Jammjammjamm in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/4
* Dependency Updates 2024-04-05 by @Jammjammjamm in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/5
* FI-2429: Migrate to HL7 validator by @dehall in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/6
* fixing typo by @rpassas in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/9
* Dependency Updates 2024-06-05 by @Jammjammjamm in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/8
* Bump core version in gemspec by @dehall in https://github.com/inferno-framework/at-home-in-vitro-test-kit/pull/7

