### PR TITLE
FI-4182 Remove inferno@groups.mitre.org email from gemspec

### DIFF
--- a/at_home_in_vitro_test_kit.gemspec
+++ b/at_home_in_vitro_test_kit.gemspec
@@ -4,7 +4,6 @@ Gem::Specification.new do |spec|
   spec.name          = 'at_home_in_vitro_test_kit'
   spec.version       = AtHomeInVitroTestKit::VERSION
   spec.authors       = ['Inferno Team']
-  spec.email         = ['inferno@groups.mitre.org']
   spec.date          = Time.now.utc.strftime('%Y-%m-%d')
   spec.summary       = 'Inferno tests for the At Home In Vitro IG'
   spec.description       = 'Inferno tests for the At Home In Vitro IG'


### PR DESCRIPTION
Email isn't required for gemspec, according to the spec: https://guides.rubygems.org/specification-reference/
